### PR TITLE
feat: restore deepin patches on lvm2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lvm2 (2.03.31-2deepin1) unstable; urgency=medium
+
+  * Restore deepin-specific patches:
+  * uniontech: add ConditionPathExistsGlob for lvm2-monitor.service
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 17 Jul 2026 10:00:00 +0800
+
 lvm2 (2.03.31-2) unstable; urgency=medium
 
   * Ask build system to install stuff writable. (closes: #1104357)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 debian-changes
+uniontech-add-condition-for-lvm2-monitor-service.patch

--- a/debian/patches/uniontech-add-condition-for-lvm2-monitor-service.patch
+++ b/debian/patches/uniontech-add-condition-for-lvm2-monitor-service.patch
@@ -1,0 +1,12 @@
+Index: deepin-lvm2/scripts/lvm2_monitoring_systemd_red_hat.service.in
+===================================================================
+--- deepin-lvm2.orig/scripts/lvm2_monitoring_systemd_red_hat.service.in
++++ deepin-lvm2/scripts/lvm2_monitoring_systemd_red_hat.service.in
+@@ -1,6 +1,7 @@
+ [Unit]
+ Description=Monitoring of LVM2 mirrors, snapshots etc. using dmeventd or progress polling
+ Documentation=man:dmeventd(8) man:lvcreate(8) man:lvchange(8) man:vgchange(8)
++ConditionPathExistsGlob=/sys/block/dm-*
+ Requires=dm-event.socket
+ After=dm-event.socket dm-event.service
+ Before=local-fs-pre.target shutdown.target


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
- uniontech monitor service patch

Related: automated backport of deepin patches.